### PR TITLE
change SwiftyJSON dependency to 2.3.1 in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ The aim of this library is to provide reusable React Native components that can 
   use_frameworks!
 
   target 'MyApp' do
-    pod 'SwiftyJSON', '~> 2.3'
+    pod 'SwiftyJSON', '2.3.1'
     pod 'Charts', '2.2.3'
   end
   ```


### PR DESCRIPTION
isExists() for JSON has not been add upon SwiftyJSON 2.3.1, and is renamed to exists() in this later PR: https://github.com/SwiftyJSON/SwiftyJSON/pull/457.

Specifying "~> 2.3.0" might not work, and let users run into the following error:

```
error: value of type 'JSON' has no member 'isExists'
```
