### PR TITLE
StartAtZero for line chart

### DIFF
--- a/RNiOSCharts/RNLineChart.swift
+++ b/RNiOSCharts/RNLineChart.swift
@@ -44,5 +44,9 @@ class RNLineChart : LineChartView {
         if json["drawMarkers"].isExists() {
           self.drawMarkers = json["drawMarkers"].boolValue;
         }
+        
+        if json["leftAxis"]["startAtZero"].isExists() {
+            self.leftAxis.startAtZeroEnabled = json["leftAxis"]["startAtZero"].boolValue;
+        }
     }
 }


### PR DESCRIPTION
Starting at zero for line charts in the same style as was already possible for bar charts.
